### PR TITLE
Invalid examples with URL instead of URI in FHIR element Encounter.class.system

### DIFF
--- a/beispiele/Example-KontaktGesundheitseinrichtung-Einrichtungskontakt.json
+++ b/beispiele/Example-KontaktGesundheitseinrichtung-Einrichtungskontakt.json
@@ -24,7 +24,7 @@
       "class": {
         "code": "IMP",
         "display": "Inpatient",
-        "system": "http://hl7.org/fhir/v3/ActCode/cs.html"
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
       },
       "subject": {
         "reference": "Patient/2b9d3335-70df-4055-b33d-27a55fe00855"

--- a/beispiele/SimpleExample-KontaktGesundheitseinrichtung-Einrichtungskontakt.json
+++ b/beispiele/SimpleExample-KontaktGesundheitseinrichtung-Einrichtungskontakt.json
@@ -24,7 +24,7 @@
       "class": {
         "code": "IMP",
         "display": "Inpatient",
-        "system": "http://hl7.org/fhir/v3/ActCode/cs.html"
+        "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
       },
       "subject": {
         "reference": "Patient/2b9d3335-70df-4055-b33d-27a55fe00855"


### PR DESCRIPTION
Found two invalid examples with URL http://hl7.org/fhir/v3/ActCode/cs.html instead of URI http://terminology.hl7.org/CodeSystem/v3-ActCode in FHIR element Encounter.class.system